### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It does not only tell you the dimensions (of your choice) but it also contains a
 ### Note
 This project works on Xcode 6.3 Swift 1.2 beta 2, but not previous releases of Xcode.
 ### Installation
-- Cocoapods: Add `pod 'TemplateImageView'` to your Podfile and `pod install`.
+- CocoaPods: Add `pod 'TemplateImageView'` to your Podfile and `pod install`.
 - Manual: Download `Classes/TemplateImageView.swift` and plug it into your code. Create a new `UIView` and change its class into `TemplateImageView`.
 
 ## Properties


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
